### PR TITLE
Вместо заглушек в SightCard и SightDetailsScreen вставлены изображения из интернета. Добавлен лоудер.

### DIFF
--- a/places/lib/ui/screen/sight_card.dart
+++ b/places/lib/ui/screen/sight_card.dart
@@ -21,7 +21,7 @@ class SightCard extends StatelessWidget {
         aspectRatio: 3 / 2,
         child: Column(
           children: [
-            TopSightCard(),
+            TopSightCard(_sight),
             BottomSightCard(_sight),
           ],
         ),
@@ -31,20 +31,40 @@ class SightCard extends StatelessWidget {
 }
 
 class TopSightCard extends StatelessWidget {
+  final Sight _sight;
+
+  TopSightCard(this._sight);
+
   @override
   Widget build(BuildContext context) {
     return Expanded(
       child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(16),
-            topRight: Radius.circular(16),
-          ),
-          color: Colors.deepPurpleAccent,
-        ),
         width: double.infinity,
         child: Stack(
           children: [
+            ClipRRect(
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(16),
+                topRight: Radius.circular(16),
+              ),
+              child: Image.network(
+                _sight.url,
+                width: double.infinity,
+                fit: BoxFit.cover,
+                loadingBuilder: (BuildContext context, Widget child,
+                    ImageChunkEvent loadingProgress) {
+                  if (loadingProgress == null) return child;
+                  return Center(
+                    child: CircularProgressIndicator(
+                      value: loadingProgress.expectedTotalBytes != null
+                          ? loadingProgress.cumulativeBytesLoaded /
+                              loadingProgress.expectedTotalBytes
+                          : null,
+                    ),
+                  );
+                },
+              ),
+            ),
             Positioned(
               right: 18,
               top: 19,

--- a/places/lib/ui/screen/sight_details.dart
+++ b/places/lib/ui/screen/sight_details.dart
@@ -17,7 +17,7 @@ class SightDetailsScreen extends StatelessWidget {
       home: Scaffold(
         body: Column(
           children: [
-            ImageSight(),
+            ImageSight(sight: sight,),
             SightInfoWidget(sight),
             BuildARouteBtn(),
             DividerSightDetailsScreen(),
@@ -45,6 +45,9 @@ class SightDetailsScreen extends StatelessWidget {
 
 /// Виджет отображения фотографии интересмного места.
 class ImageSight extends StatelessWidget {
+  final Sight sight;
+
+  const ImageSight({this.sight});
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -52,7 +55,23 @@ class ImageSight extends StatelessWidget {
         Container(
           width: double.infinity,
           height: 360,
-          color: Colors.deepPurpleAccent,
+          child: Image.network(
+            sight.url,
+            width: double.infinity,
+            fit: BoxFit.cover,
+            loadingBuilder: (BuildContext context, Widget child,
+                ImageChunkEvent loadingProgress) {
+              if (loadingProgress == null) return child;
+              return Center(
+                child: CircularProgressIndicator(
+                  value: loadingProgress.expectedTotalBytes != null
+                      ? loadingProgress.cumulativeBytesLoaded /
+                      loadingProgress.expectedTotalBytes
+                      : null,
+                ),
+              );
+            },
+          ),
         ),
         Positioned(
           top: 36,


### PR DESCRIPTION
https://user-images.githubusercontent.com/72078435/100783528-f3454b00-341e-11eb-8882-d9ce21f4e5bc.png
https://user-images.githubusercontent.com/72078435/100783532-f4767800-341e-11eb-9ed6-f2f1e23d825a.png
https://user-images.githubusercontent.com/72078435/100783533-f50f0e80-341e-11eb-8af0-36342161a626.png
https://user-images.githubusercontent.com/72078435/100783535-f50f0e80-341e-11eb-8671-9d88a912a82f.png
https://user-images.githubusercontent.com/72078435/100783537-f5a7a500-341e-11eb-806f-bf92f8fb5d1b.png
